### PR TITLE
Fix: Visual focus bug for overlapping dates (1/29 & 12/29)

### DIFF
--- a/bubble-datepicker.go
+++ b/bubble-datepicker.go
@@ -271,9 +271,9 @@ func (m Model) View() string {
 		textStyle := m.Styles.Text
 		if !m.Selected {
 			// skip modifications to the date
-		} else if day.Day() == m.Time.Day() && day.Month() == day.Month() && m.Focused == FocusCalendar {
+		} else if day.Day() == m.Time.Day() && day.Month() == m.Time.Month() && m.Focused == FocusCalendar {
 			textStyle = m.Styles.FocusedText
-		} else if day.Day() == m.Time.Day() && day.Month() == day.Month() {
+		} else if day.Day() == m.Time.Day() && day.Month() == m.Time.Month() {
 			textStyle = m.Styles.SelectedText
 		}
 


### PR DESCRIPTION
Bug: selected conditional check only checks days but not the month because day.Month() == day.Month() is always true. I fixed this to day.Month() == m.Time.Month() so that the month is checked alongside the day.

This caused the focused day background to be highlighted across months in the grid. See below that 12/29 is being highlighted alongside 1/29. I noticed this bug after implementing a .Reverse(true) on the focused text styling to get the appearance of a cursor.

| Before | After |
| :--- | :--- |
| <img width="223" height="227" alt="withBug" src="https://github.com/user-attachments/assets/3e14ea11-329b-45a2-acae-cc19f07806f7" /> | <img width="221" height="221" alt="woBug" src="https://github.com/user-attachments/assets/c553a7cf-8ad9-496f-a402-607e077906ad" /> |