### PR TITLE
Allows tab to wrap focus back to month header

### DIFF
--- a/bubble-datepicker.go
+++ b/bubble-datepicker.go
@@ -105,7 +105,7 @@ func New(time time.Time) Model {
 		KeyMap: DefaultKeyMap(),
 		Styles: DefaultStyles(),
 
-		Focused: FocusCalendar,
+		Focused:  FocusCalendar,
 		Selected: false,
 	}
 }

--- a/bubble-datepicker.go
+++ b/bubble-datepicker.go
@@ -149,6 +149,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.SetFocus(FocusHeaderYear)
 			case FocusHeaderYear:
 				m.SetFocus(FocusCalendar)
+			case FocusCalendar:
+				m.SetFocus(FocusHeaderMonth)
 			}
 		}
 	}

--- a/bubble-datepicker.go
+++ b/bubble-datepicker.go
@@ -38,6 +38,10 @@ type KeyMap struct {
 	Left      key.Binding
 	FocusPrev key.Binding
 	FocusNext key.Binding
+	NextMonth key.Binding
+	LastMonth key.Binding
+	NextYear  key.Binding
+	LastYear  key.Binding
 	Quit      key.Binding
 }
 
@@ -50,6 +54,10 @@ func DefaultKeyMap() KeyMap {
 		Left:      key.NewBinding(key.WithKeys("left", "h")),
 		FocusPrev: key.NewBinding(key.WithKeys("shift+tab")),
 		FocusNext: key.NewBinding(key.WithKeys("tab")),
+		NextMonth: key.NewBinding(key.WithKeys("J")),
+		LastMonth: key.NewBinding(key.WithKeys("K")),
+		NextYear:  key.NewBinding(key.WithKeys("L")),
+		LastYear:  key.NewBinding(key.WithKeys("H")),
 		Quit:      key.NewBinding(key.WithKeys("ctrl+c", "q")),
 	}
 }
@@ -134,6 +142,18 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		case key.Matches(msg, m.KeyMap.Left):
 			m.updateLeft()
+
+		case key.Matches(msg, m.KeyMap.NextMonth):
+			m.NextMonth()
+
+		case key.Matches(msg, m.KeyMap.LastMonth):
+			m.LastMonth()
+
+		case key.Matches(msg, m.KeyMap.NextYear):
+			m.NextYear()
+
+		case key.Matches(msg, m.KeyMap.LastYear):
+			m.LastYear()
 
 		case key.Matches(msg, m.KeyMap.FocusPrev):
 			switch m.Focused {

--- a/examples/textinput/main.go
+++ b/examples/textinput/main.go
@@ -24,127 +24,126 @@ import (
 type focus int
 
 const (
-    FocusNone focus = iota
-    FocusInput
-    FocusDatePicker
+	FocusNone focus = iota
+	FocusInput
+	FocusDatePicker
 )
 
 type Model struct {
-    focus focus
-    input textinput.Model
-    datepicker datepicker.Model
+	focus      focus
+	input      textinput.Model
+	datepicker datepicker.Model
 }
 
 var inputStyles = lipgloss.NewStyle().Padding(1, 1, 0)
 
 func initializeModel() tea.Model {
-    dp := datepicker.New(time.Now())
+	dp := datepicker.New(time.Now())
 
-    input := textinput.New()
-    input.Placeholder = "YYYY-MM-DD (enter date)"
-    input.Focus()
-    input.Width = 20
+	input := textinput.New()
+	input.Placeholder = "YYYY-MM-DD (enter date)"
+	input.Focus()
+	input.Width = 20
 
-    return Model{
-        focus: FocusInput,
-        input: input,
-        datepicker: dp,
-    }
+	return Model{
+		focus:      FocusInput,
+		input:      input,
+		datepicker: dp,
+	}
 }
 
 func (m Model) Init() tea.Cmd {
-    return textinput.Blink
+	return textinput.Blink
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    var cmd tea.Cmd
+	var cmd tea.Cmd
 
-    switch msg := msg.(type) {
-    case tea.WindowSizeMsg:
-        // TODO figure out how we want to size things
-        // we'll probably want both bubbles to be vertically stacked
-        // and to take as much room as the can
-        return m, nil
-    case tea.KeyMsg:
-        switch msg.String() {
-        case "ctrl+c", "q":
-            return m, tea.Quit
-        case "tab":
-            if m.focus == FocusInput {
-                m.focus = FocusDatePicker
-                m.input.Blur()
-                m.input.SetValue(m.datepicker.Time.Format(time.DateOnly))
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		// TODO figure out how we want to size things
+		// we'll probably want both bubbles to be vertically stacked
+		// and to take as much room as the can
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		case "tab":
+			if m.focus == FocusInput {
+				m.focus = FocusDatePicker
+				m.input.Blur()
+				m.input.SetValue(m.datepicker.Time.Format(time.DateOnly))
 
-                m.datepicker.SelectDate()
-                m.datepicker.SetFocus(datepicker.FocusHeaderMonth)
-                m.datepicker = m.datepicker
-                return m, nil
+				m.datepicker.SelectDate()
+				m.datepicker.SetFocus(datepicker.FocusHeaderMonth)
+				m.datepicker = m.datepicker
+				return m, nil
 
-            }
-        case "shift+tab":
-            if m.focus == FocusDatePicker && m.datepicker.Focused == datepicker.FocusHeaderMonth {
-                m.focus = FocusInput
-                m.datepicker.Blur()
+			}
+		case "shift+tab":
+			if m.focus == FocusDatePicker && m.datepicker.Focused == datepicker.FocusHeaderMonth {
+				m.focus = FocusInput
+				m.datepicker.Blur()
 
-                m.input.Focus()
-                return m, nil
-            }
-        }
-    }
+				m.input.Focus()
+				return m, nil
+			}
+		}
+	}
 
-    switch m.focus {
-    case FocusInput:
-        m.input, cmd = m.UpdateInput(msg)
-    case FocusDatePicker:
-        m.datepicker, cmd = m.UpdateDatepicker(msg)
-    case FocusNone:
-        // do nothing
-    }
+	switch m.focus {
+	case FocusInput:
+		m.input, cmd = m.UpdateInput(msg)
+	case FocusDatePicker:
+		m.datepicker, cmd = m.UpdateDatepicker(msg)
+	case FocusNone:
+		// do nothing
+	}
 
-    return  m, cmd 
+	return m, cmd
 }
 
-
 func (m Model) View() string {
-    return lipgloss.JoinVertical(lipgloss.Left, inputStyles.Render(m.input.View()), m.datepicker.View())
+	return lipgloss.JoinVertical(lipgloss.Left, inputStyles.Render(m.input.View()), m.datepicker.View())
 }
 
 func (m *Model) UpdateInput(msg tea.Msg) (textinput.Model, tea.Cmd) {
-    var cmd tea.Cmd
+	var cmd tea.Cmd
 
-    m.input, cmd = m.input.Update(msg)
+	m.input, cmd = m.input.Update(msg)
 
-    val := m.input.Value()
-    t, err := time.Parse(time.DateOnly, strings.TrimSpace(val))
-    if err == nil {
-        m.datepicker.SetTime(t)
-        m.datepicker.SelectDate()
-        m.datepicker.Blur()
-    } 
-    if err != nil && m.datepicker.Selected {
-        m.datepicker.UnselectDate()
-    }
+	val := m.input.Value()
+	t, err := time.Parse(time.DateOnly, strings.TrimSpace(val))
+	if err == nil {
+		m.datepicker.SetTime(t)
+		m.datepicker.SelectDate()
+		m.datepicker.Blur()
+	}
+	if err != nil && m.datepicker.Selected {
+		m.datepicker.UnselectDate()
+	}
 
-    return m.input, cmd
+	return m.input, cmd
 }
 
 func (m *Model) UpdateDatepicker(msg tea.Msg) (datepicker.Model, tea.Cmd) {
-    var cmd tea.Cmd
+	var cmd tea.Cmd
 
-    prev := m.datepicker.Time
+	prev := m.datepicker.Time
 
-    m.datepicker, cmd = m.datepicker.Update(msg)
+	m.datepicker, cmd = m.datepicker.Update(msg)
 
-    if prev != m.datepicker.Time {
-        m.input.SetValue(m.datepicker.Time.Format(time.DateOnly))
-    }
+	if prev != m.datepicker.Time {
+		m.input.SetValue(m.datepicker.Time.Format(time.DateOnly))
+	}
 
-    return m.datepicker, cmd
+	return m.datepicker, cmd
 }
 
 func main() {
-    p := tea.NewProgram(initializeModel())
-    if _, err := p.Run(); err != nil {
-        log.Fatalf("alas, an error %s", err)
-    }
+	p := tea.NewProgram(initializeModel())
+	if _, err := p.Run(); err != nil {
+		log.Fatalf("alas, an error %s", err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethanefung/bubble-datepicker
+module github.com/cskeeters/bubble-datepicker
 
 go 1.21.1
 


### PR DESCRIPTION
This change enables the user to change focus from the calendar (day) to the month by pressing tab.

Currently, this can only be done by pressing Shift+Tab twice, which is awkward to type.